### PR TITLE
fixing startAfterParameter

### DIFF
--- a/DMSCDC_LoadIncremental.py
+++ b/DMSCDC_LoadIncremental.py
@@ -39,7 +39,8 @@ partition_keys = args['partitionKey']
 
 # gets list of files to process
 inputFileList = []
-results = s3conn.list_objects_v2(Bucket=args['bucket'], Prefix=args['prefix'] +'2', StartAfter=args['lastIncrementalFile']).get('Contents')
+startAfterParameter = last_file[len(args['bucket']) + 1:]
+results = s3conn.list_objects_v2(Bucket=args['bucket'], Prefix=args['prefix'] +'2', StartAfter=startAfterParameter).get('Contents')
 for result in results:
     if (args['bucket'] + '/' + result['Key'] != last_file):
         inputFileList.append('s3://' + args['bucket'] + '/' + result['Key'])

--- a/DMSCDC_ProcessTable.py
+++ b/DMSCDC_ProcessTable.py
@@ -90,7 +90,8 @@ if loadInitial:
 
 loadIncremental = False
 #Get the latest incremental file
-incrementalFiles = s3conn.list_objects_v2(Bucket=bucket, Prefix=full_folder+'2', StartAfter=lastIncrementalFile).get('Contents')
+startAfterParameter = lastIncrementalFile[len(bucket) + 1:]
+incrementalFiles = s3conn.list_objects_v2(Bucket=bucket, Prefix=full_folder+'2', StartAfter=startAfterParameter).get('Contents')
 if incrementalFiles is not None:
     filecount = len(incrementalFiles)
     newIncrementalFile = bucket + '/' + incrementalFiles[filecount-1]['Key']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updating the startAfterParameter, it requires the object key, and the currently supplied lastIncrementalFile parameter has the bucket name prefix that we need to get rid of.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
